### PR TITLE
Trovo uses HLS for VOD streams

### DIFF
--- a/src/streamlink/plugins/trovo.py
+++ b/src/streamlink/plugins/trovo.py
@@ -1,6 +1,7 @@
 import re
 
 from streamlink.stream import HTTPStream
+from streamlink.stream import HLSStream
 from streamlink.plugin import Plugin
 
 
@@ -15,7 +16,10 @@ class Trovo(Plugin):
     def _get_streams(self):
         res = self.session.http.get(self.url)
         for m in self.streams_re.finditer(res.text):
-            yield m.group(2), HTTPStream(self.session, m.group(1).replace('\\u002F', '/'))
+            if "liveplay.trovo.live" in m.group(1):
+                yield m.group(2), HTTPStream(self.session, m.group(1).replace('\\u002F', '/'))
+            elif "vod.trovo.live" in m.group(1):
+                yield m.group(2), HLSStream(self.session, m.group(1).replace('\\u002F', '/'))
 
 
 __plugin__ = Trovo

--- a/src/streamlink/plugins/trovo.py
+++ b/src/streamlink/plugins/trovo.py
@@ -3,7 +3,7 @@ import re
 from streamlink.stream import HTTPStream
 from streamlink.stream import HLSStream
 from streamlink.plugin import Plugin
-
+import datetime
 
 class Trovo(Plugin):
     url_re = re.compile(r"https?://(?:www\.)?trovo\.live/")
@@ -15,11 +15,12 @@ class Trovo(Plugin):
 
     def _get_streams(self):
         res = self.session.http.get(self.url)
+        self.session.http.headers.update({'Origin': "https://trovo.live"})
         for m in self.streams_re.finditer(res.text):
             if "liveplay.trovo.live" in m.group(1):
-                yield m.group(2), HTTPStream(self.session, m.group(1).replace('\\u002F', '/'))
+                yield m.group(2), HTTPStream(self.session, m.group(1).replace('\\u002F', '/') + "&_f_=" + str(int((datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)).total_seconds() * 1000)))
             elif "vod.trovo.live" in m.group(1):
-                yield m.group(2), HLSStream(self.session, m.group(1).replace('\\u002F', '/'))
+                yield m.group(2), HLSStream(self.session, m.group(1).replace('\\u002F', '/') + "&_f_=" + str(int((datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)).total_seconds() * 1000)))
 
 
 __plugin__ = Trovo


### PR DESCRIPTION
Add support for video on demand streams that use HLS instead.  Live continues to use HTTP.